### PR TITLE
Fix 3.7.0 + postpone canary-3.8.0

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,8 +15,8 @@
 
               section Canary
               Consensus V6 active (5/02 block 6,225,000):active, 05/02/2025, 1d
-              v3.8.0 (5/27):active, c2, 5/27/2025, 1d
-              Consensus V7 active (5/30 block 7,616,462):active, 05/30/2025, 1d
+              v3.8.0 (6/3):active, c2, 6/03/2025, 1d
+              Consensus V7 active (6/6 block 7,771,538):active, 06/06/2025, 1d
               
               section Testnet
               v3.7.0 (05/13):active, c2, 5/13/2025, 1d

--- a/index.html
+++ b/index.html
@@ -14,22 +14,22 @@
               - : 05/02/2025,
 
               section Canary
-              Consensus V6 active (5/02 block 6,225,000):active, 05/02/2025, 1d
+              Consensus V6 active (5/02 block 6,240,000):active, 05/02/2025, 1d
               v3.8.0 (6/3):active, c2, 6/03/2025, 1d
-              Consensus V7 active (6/6 block 7,771,538):active, 06/06/2025, 1d
+              Consensus V7 active (6/6 block 7,771,000):active, 06/06/2025, 1d
               
               section Testnet
               v3.7.0 (05/13):active, c2, 5/13/2025, 1d
-              Consensus V6 active (05/27 block 7,625,000):active, t3, 05/18/2025, 1d
+              Consensus V6 active (05/27 block 7,600,000):active, t3, 05/18/2025, 1d
               v3.8.0 (6/10):active, c2, 6/10/2025, 1d
-              Consensus V7 active (6/15 block 8,121,527):active, 06/15/2025, 1d
+              Consensus V7 active (6/15 block 8,121,000):active, 06/15/2025, 1d
               
               section Mainnet
               Consensus V5 active (5/06 block 7,060,000):active, m3, 05/06/2025, 1d
               v3.7.0 (05/20):active, c2, 5/20/2025, 1d
-              Consensus V6 active (6/03 block 7,820,000):active, m3, 06/03/2025, 1d
+              Consensus V6 active (6/03 block 7,557,000):active, m3, 06/03/2025, 1d
               v3.8.0 (6/17):active, c2, 6/17/2025, 1d
-              Consensus V7 active (6/18 block 8,355,545):active, 06/18/2025, 1d
+              Consensus V7 active (6/18 block 8,355,000):active, 06/18/2025, 1d
 
               section Leo
               Leo v2.6.0 (05/20):active, m2, 05/20/2025, 1d

--- a/index.html
+++ b/index.html
@@ -20,7 +20,7 @@
               
               section Testnet
               v3.7.0 (05/13):active, c2, 5/13/2025, 1d
-              Consensus V6 active (05/27 block 7,600,000):active, t3, 05/18/2025, 1d
+              Consensus V6 active (5/18 block 7,600,000):active, t3, 05/18/2025, 1d
               v3.8.0 (6/10):active, c2, 6/10/2025, 1d
               Consensus V7 active (6/15 block 8,121,000):active, 06/15/2025, 1d
               


### PR DESCRIPTION
- Postponing because both Ray and I are OOO.
- Aligns canary-3.7.0 and testnet-3.7.0 with canary branch ([canary link](https://github.com/ProvableHQ/snarkVM/blob/canary/console/network/src/canary_v0.rs#L145)) ([testnet link](https://github.com/ProvableHQ/snarkVM/blob/canary/console/network/src/testnet_v0.rs#L145))
- 3.7.0 for mainnet is pulled ahead so its ~24 hours after mainnet release.